### PR TITLE
Sets the SourceFormat for gcsRef when JSON is requested in gcs2bq

### DIFF
--- a/internal/action/gcs2bq/constants.go
+++ b/internal/action/gcs2bq/constants.go
@@ -4,5 +4,4 @@ const (
 	MODE_CREATE     = "create"
 	MODE_AUTODETECT = "autodetect"
 	MODE_APPEND     = "append"
-	DATAFORMAT_JSON = "JSON"
 )

--- a/internal/action/gcs2bq/import.go
+++ b/internal/action/gcs2bq/import.go
@@ -59,7 +59,7 @@ func executeCreateMode(
 	common.BigQueryCreateTable(ctx, table, params.Schema, params.PartitionTimeField, clusteredFields, params.Labels)
 	gcsRef := common.BigQueryGetStorageRef(
 		params.BucketUri,
-		params.TableName,
+		params.SourceDataFormat,
 	)
 	loader := table.LoaderFrom(gcsRef)
 	runLoader(ctx, loader)
@@ -75,7 +75,7 @@ func executeAutodetectMode(ctx context.Context, table *bigquery.Table, params ty
 	}
 	gcsRef := common.BigQueryGetStorageRef(
 		params.BucketUri,
-		params.TableName,
+		params.SourceDataFormat,
 	)
 	gcsRef.FileConfig.AutoDetect = true
 	gcsRef.FileConfig.Schema = nil
@@ -93,7 +93,7 @@ func executeAppendMode(ctx context.Context, table *bigquery.Table, params types.
 	}
 	gcsRef := common.BigQueryGetStorageRef(
 		params.BucketUri,
-		params.TableName,
+		params.SourceDataFormat,
 	)
 	loader := table.LoaderFrom(gcsRef)
 	runLoader(ctx, loader)

--- a/internal/common/bigquery.go
+++ b/internal/common/bigquery.go
@@ -372,12 +372,12 @@ func BigQueryGetStorageRef(
 	bucketUri string,
 	sourceDataFormat string,
 ) *bigquery.GCSReference {
-	log.Printf("→ GCS →→ Getting gcsRef from uri %s", bucketUri)
+	log.Printf("→ GCS →→ Getting gcsRef from uri %s, format %s", bucketUri, sourceDataFormat)
 	gcsRef := bigquery.NewGCSReference(bucketUri)
 
 	var dataFormat bigquery.DataFormat
 	if sourceDataFormat == "JSON" {
-		dataFormat = "JSON"
+		dataFormat = bigquery.JSON
 	}
 
 	gcsRef.FileConfig = bigquery.FileConfig{SourceFormat: dataFormat}


### PR DESCRIPTION
- Passing the `SourceDataFormat` params when setting the gcsRef for loading from file to BigQuery.
- Sets `bigquery.JSON` for dateFormat to fix the error:
  ```2023/12/20 17:34:27 → GCS →→ Error after running loader {Location: ""; Message: "Error while reading data, error message: CSV processing encountered too many errors, giving up. Rows: 0; errors: 6; max bad: 0; error percent: 0"; Reason: "invalid"}```
- Deletes the `DATAFORMAT_JSON` from constants that was not in use.

Testing:
Created the image `gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-tool:dPIPELINE-1549` for testing purposes.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1549