### PR TITLE
Decrease the number of threads and batch size to import data using BQ2ES

### DIFF
--- a/internal/action/bq2es/export-data-bq-to-es.go
+++ b/internal/action/bq2es/export-data-bq-to-es.go
@@ -50,8 +50,8 @@ func ExportBigQueryToElasticSearch(params types.BQ2ESImportConfig) {
 		common.ElasticSearchRecreateIndex(params.ElasticSearchUrl, params.IndexName)
 	}
 	var wg sync.WaitGroup
-	const threads = 15
-	const Batch = 2000
+	const threads = 10
+	const Batch = 1000
 
 	log.Println("→ ES →→ Importing data to ElasticSearch")
 	log.Printf("→ ES →→ Opening [%s] threads", threads)


### PR DESCRIPTION
This pull request includes a change to the `ExportBigQueryToElasticSearch` function in the `internal/action/bq2es/export-data-bq-to-es.go` file to optimize the import process by adjusting the number of threads and batch size.

Optimization of import process:

* [`internal/action/bq2es/export-data-bq-to-es.go`](diffhunk://#diff-9ba7435442785ec527dacec3ab0f066a9806337bece24fdbb2fe4bdc2681c4b9L53-R54): Reduced the number of threads from 15 to 10 and decreased the batch size from 2000 to 1000 to improve performance and resource utilization.