### PR TITLE
Increase the number of threads and batch size to import data using BQ2ES

### DIFF
--- a/internal/action/bq2es/export-data-bq-to-es.go
+++ b/internal/action/bq2es/export-data-bq-to-es.go
@@ -50,8 +50,8 @@ func ExportBigQueryToElasticSearch(params types.BQ2ESImportConfig) {
 		common.ElasticSearchRecreateIndex(params.ElasticSearchUrl, params.IndexName)
 	}
 	var wg sync.WaitGroup
-	const threads = 10
-	const Batch = 1000
+	const threads = 15
+	const Batch = 2500
 
 	log.Println("→ ES →→ Importing data to ElasticSearch")
 	log.Printf("→ ES →→ Opening [%s] threads", threads)


### PR DESCRIPTION
This pull request includes changes to the `internal/action/bq2es/export-data-bq-to-es.go` file to improve the performance of exporting data from BigQuery to ElasticSearch. The most important changes include increasing the number of threads and the batch size used in the export process.

Performance improvements:

* [`internal/action/bq2es/export-data-bq-to-es.go`](diffhunk://#diff-9ba7435442785ec527dacec3ab0f066a9806337bece24fdbb2fe4bdc2681c4b9L53-R54): Increased the number of threads from 10 to 15 to allow for more concurrent operations.
* [`internal/action/bq2es/export-data-bq-to-es.go`](diffhunk://#diff-9ba7435442785ec527dacec3ab0f066a9806337bece24fdbb2fe4bdc2681c4b9L53-R54): Increased the batch size from 1000 to 2500 to process larger chunks of data at once.